### PR TITLE
add missing cake dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "cake build && nodeunit test",
     "prepublish": "cake build"}
 , "devDependencies": {
+    "cake": "^0.1.1", 
     "eyes": "~0.1.8",
     "debug": "~0.7.4",
     "nodeunit": ">= 0.5.4",


### PR DESCRIPTION
`cake` as a dependency has been missing on my machine as I usually don't work with coffee-script. This resulted in failed builds on my machine. Here's a pull-request to fix that.

Cheers! 
